### PR TITLE
Path update for lpass via homebrew

### DIFF
--- a/workflow/info.plist
+++ b/workflow/info.plist
@@ -302,6 +302,10 @@ tell application "Finder"
 		set lpass_binary to "/usr/local/bin/lpass"
 	else if exists POSIX file "/opt/local/bin/lpass" then
 		set lpass_binary to "/opt/local/bin/lpass"
+	else if exists POSIX file "/opt/homebrew/bin/lpass" then
+		set lpass_binary to "/opt/homebrew/bin/lpass"
+    else
+        display notification "Error: could not find lpass binary" with title "LastPass Error"
 	end if
 end tell
 
@@ -314,7 +318,7 @@ end if
 do shell script "/bin/bash -c '" &amp; "export TERM=\"xterm-256color\" &amp;&amp; export LPASS_ASKPASS=\"" &amp; osascript &amp; "\" &amp;&amp; export LPASS_AGENT_TIMEOUT=" &amp; login_timeout &amp; " &amp;&amp; " &amp; lpass_binary &amp; " login --trust \"" &amp; login_email &amp; "\" &amp;&amp; clear &amp;&amp; " &amp; lpass_binary &amp; " ls --sync=now &gt; /dev/null 2&gt;&amp;1 &amp;&amp; exit 0'"
 
 if ("{query}" = "scriptlocationnotset") then
-tell application "Alfred 3" to search "lp "
+tell application "Alfred 5" to search "lp "
 end if</string>
 				<key>scriptargtype</key>
 				<integer>0</integer>
@@ -411,7 +415,7 @@ exit 1;
 } else {
 
 my $lpass_exec;
-foreach my $f (qw@lpass /usr/local/bin/lpass /opt/local/bin/lpass /usr/bin/lpass@) {
+foreach my $f (qw@lpass /opt/homebrew/bin/lpass /usr/local/bin/lpass /opt/local/bin/lpass /usr/bin/lpass@) {
     $lpass_exec = $f
         if (-x $f);
 }
@@ -528,7 +532,7 @@ my ($agent, $agentErr, $agentErrCode) = capture {
 };
 
 my $lpass_exec;
-foreach my $f (qw@lpass /usr/local/bin/lpass /opt/local/bin/lpass /usr/bin/lpass@) {
+foreach my $f (qw@lpass /opt/homebrew/bin/lpass /usr/local/bin/lpass /opt/local/bin/lpass /usr/bin/lpass@) {
     $lpass_exec = $f
         if (-x $f);
 }
@@ -663,7 +667,7 @@ exit 1;
 } else {
 
 my $lpass_exec;
-foreach my $f (qw@lpass /usr/local/bin/lpass /opt/local/bin/lpass /usr/bin/lpass@) {
+foreach my $f (qw@lpass /opt/homebrew/bin/lpass /usr/local/bin/lpass /opt/local/bin/lpass /usr/bin/lpass@) {
     $lpass_exec = $f
         if (-x $f);
 }
@@ -762,7 +766,7 @@ print $results;
 				<integer>127</integer>
 				<key>script</key>
 				<string>#!/bin/bash
-for f in lpass /usr/local/bin/lpass /opt/local/bin/lpass /usr/bin/lpass; do
+for f in lpass /opt/homebrew/bin/lpass /usr/local/bin/lpass /opt/local/bin/lpass /usr/bin/lpass; do
     if test -x $f; then
         lpass_exec=$f
     fi
@@ -821,7 +825,7 @@ my ($agent, $agentErr, $agentErrCode) = capture {
 };
 
 my $lpass_exec;
-foreach my $f (qw@lpass /usr/local/bin/lpass /opt/local/bin/lpass /usr/bin/lpass@) {
+foreach my $f (qw@lpass /opt/homebrew/bin/lpass /usr/local/bin/lpass /opt/local/bin/lpass /usr/bin/lpass@) {
     $lpass_exec = $f
         if (-x $f);
 }


### PR DESCRIPTION
The workflow didn't work for me as I could not login and, when fixed that issue, could not search for LastPass entries.

I found that the path to the lpass binary was not in the script. Homebrew installed it to /opt/homebrew/bin/lpass. I added this path to the script.

Also, Alfred was not opened because the script mentioned version 3 of Alfred. I changed this to the current version 5. 

- added path to lpass binary for homebrews location: /opt/homebrew/bin/lpass
- updated used Alfred version from 3 to 5